### PR TITLE
client: round up for gas price and limit

### DIFF
--- a/client/lcdclient.go
+++ b/client/lcdclient.go
@@ -89,7 +89,7 @@ func (lcd *LCDClient) CreateAndSignTx(ctx context.Context, options CreateTxOptio
 			return nil, sdkerrors.Wrap(err, "failed to simulate")
 		}
 
-		gasLimit = lcd.GasAdjustment.MulInt64(int64(simulateRes.GasInfo.GasUsed)).TruncateInt64()
+		gasLimit = lcd.GasAdjustment.MulInt64(int64(simulateRes.GasInfo.GasUsed)).Ceil().RoundInt64()
 		txbuilder.SetGasLimit(uint64(gasLimit))
 	}
 
@@ -99,7 +99,7 @@ func (lcd *LCDClient) CreateAndSignTx(ctx context.Context, options CreateTxOptio
 			return nil, sdkerrors.Wrap(err, "failed to compute tax")
 		}
 
-		gasFee := msg.NewCoin(lcd.GasPrice.Denom, lcd.GasPrice.Amount.MulInt64(gasLimit).TruncateInt())
+		gasFee := msg.NewCoin(lcd.GasPrice.Denom, lcd.GasPrice.Amount.MulInt64(gasLimit).Ceil().RoundInt())
 		txbuilder.SetFeeAmount(computeTaxRes.TaxAmount.Add(gasFee))
 	}
 


### PR DESCRIPTION
Truncating prevents using the exact min gas price in some cases, e.g.:
`tx failed with code 13: insufficient fees; got: "117uluna", required: "118uluna" = "118uluna"(gas) +""(stability): insufficient fee`